### PR TITLE
build: introduce java-module-dependencies and remove build.gradle files

### DIFF
--- a/gradle/modules.properties
+++ b/gradle/modules.properties
@@ -1,0 +1,1 @@
+systems.comodal.json_iterator=software.sava:json-iterator

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -7,5 +7,8 @@ repositories {
 }
 
 dependencies {
+  implementation("org.gradlex:java-module-dependencies:1.9.1")
+  implementation("org.gradlex:java-module-testing:1.7")
+  implementation("org.gradlex:jvm-dependency-conflict-resolution:2.4")
   implementation("com.github.iherasymenko.jlink:jlink-plugin:0.7")
 }

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -7,6 +7,7 @@ repositories {
 }
 
 dependencies {
+  implementation("com.autonomousapps:dependency-analysis-gradle-plugin:2.18.0")
   implementation("org.gradlex:java-module-dependencies:1.9.1")
   implementation("org.gradlex:java-module-testing:1.7")
   implementation("org.gradlex:jvm-dependency-conflict-resolution:2.4")

--- a/gradle/plugins/src/main/kotlin/software.sava.gradle.base.dependency-rules.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/software.sava.gradle.base.dependency-rules.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  id("org.gradlex.jvm-dependency-conflict-resolution")
+}
+
+jvmDependencyConflicts {
+  consistentResolution {
+    platform(":versions")
+  }
+}

--- a/gradle/plugins/src/main/kotlin/software.sava.gradle.base.dependency-rules.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/software.sava.gradle.base.dependency-rules.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   id("org.gradlex.jvm-dependency-conflict-resolution")
 }
 
+// NOTE: This may refer directly to published BOM and 'gradle/versions' can be removed
 jvmDependencyConflicts {
   consistentResolution {
     platform(":versions")

--- a/gradle/plugins/src/main/kotlin/software.sava.gradle.build.settings.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/software.sava.gradle.build.settings.gradle.kts
@@ -1,11 +1,6 @@
 plugins {
   id("software.sava.gradle.base.repositories")
+  id("org.gradlex.java-module-dependencies")
 }
 
-@Suppress("UnstableApiUsage")
-gradle.lifecycle.beforeProject {
-  if (path != ":") {
-    group = "software.sava"
-    apply(plugin = "software.sava.gradle.java-module")
-  }
-}
+includeBuild(".")

--- a/gradle/plugins/src/main/kotlin/software.sava.gradle.check.dependencies.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/software.sava.gradle.check.dependencies.gradle.kts
@@ -1,7 +1,13 @@
 import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesOrderingCheck
 
 plugins {
+  id("java")
   id("com.autonomousapps.dependency-analysis")
+  id("org.gradlex.java-module-dependencies")
 }
 
 tasks.withType<ModuleDirectivesOrderingCheck>().configureEach { enabled = false }
+
+tasks.check {
+  dependsOn(tasks.checkAllModuleInfo)
+}

--- a/gradle/plugins/src/main/kotlin/software.sava.gradle.check.dependencies.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/software.sava.gradle.check.dependencies.gradle.kts
@@ -1,0 +1,7 @@
+import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesOrderingCheck
+
+plugins {
+  id("com.autonomousapps.dependency-analysis")
+}
+
+tasks.withType<ModuleDirectivesOrderingCheck>().configureEach { enabled = false }

--- a/gradle/plugins/src/main/kotlin/software.sava.gradle.feature.test.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/software.sava.gradle.feature.test.gradle.kts
@@ -2,10 +2,11 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 
 plugins {
   id("java")
+  id("org.gradlex.java-module-dependencies")
+  id("org.gradlex.java-module-testing")
 }
 
 tasks.test {
-  useJUnitPlatform()
   testLogging {
     events("passed", "skipped", "failed", "standardOut", "standardError")
     exceptionFormat = FULL
@@ -13,15 +14,19 @@ tasks.test {
   }
 }
 
-dependencies {
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-}
-
-// access catalog for junit version
-// https://github.com/gradle/gradle/issues/15383
+// remove automatically added compile time dependencies for strict dependency analysis
 configurations.testImplementation {
   withDependencies {
-    val libs = the<VersionCatalogsExtension>().named("libs")
-    add(libs.findLibrary("junit-jupiter").get().get())
+    removeIf { it.group == "org.junit.jupiter" && it.name == "junit-jupiter" }
+  }
+}
+
+val projectHasTests = project.layout.projectDirectory.dir("src/test/java").asFile.isDirectory
+
+if (projectHasTests) {
+  testModuleInfo {
+    requires("org.junit.jupiter.api")
+    requires("jdk.httpserver")
+    runtimeOnly("org.junit.jupiter.engine")
   }
 }

--- a/gradle/versions/build.gradle.kts
+++ b/gradle/versions/build.gradle.kts
@@ -8,3 +8,7 @@ dependencies.constraints {
     }
   }
 }
+
+dependencies.constraints {
+  api("org.junit.jupiter:junit-jupiter-api:${libs.junit.jupiter.get().version}")
+}

--- a/gradle/versions/build.gradle.kts
+++ b/gradle/versions/build.gradle.kts
@@ -1,3 +1,4 @@
+// NOTE: This file is not necessary when BOM is published
 dependencies.constraints {
   val libs = versionCatalogs.named("libs")
   val catalogEntries = libs.libraryAliases.map { libs.findLibrary(it).get().get() }
@@ -9,6 +10,7 @@ dependencies.constraints {
   }
 }
 
+// Temporarily until 'org.junit.jupiter:junit-jupiter-api' is in catalog (and/or BOM)
 dependencies.constraints {
   api("org.junit.jupiter:junit-jupiter-api:${libs.junit.jupiter.get().version}")
 }

--- a/gradle/versions/build.gradle.kts
+++ b/gradle/versions/build.gradle.kts
@@ -1,0 +1,10 @@
+dependencies.constraints {
+  val libs = versionCatalogs.named("libs")
+  val catalogEntries = libs.libraryAliases.map { libs.findLibrary(it).get().get() }
+  catalogEntries.forEach { entry ->
+    val version = entry.version
+    if (version != null) {
+      api(entry) { version { require(version) } }
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,14 +7,18 @@ plugins {
 
 rootProject.name = "sava"
 
-include(":sava-core")
-project(":sava-core").projectDir = file("core")
-include(":sava-rpc")
-project(":sava-rpc").projectDir = file("rpc")
-include(":sava-examples")
-project(":sava-examples").projectDir = file("examples")
-include(":sava-vanity")
-project(":sava-vanity").projectDir = file("vanity")
+javaModules {
+  directory(".") {
+    group = "software.sava"
+    plugin("software.sava.gradle.java-module")
+
+    module("core") { artifact = "sava-core" }
+    module("examples") { artifact = "sava-examples" }
+    module("rpc") { artifact = "sava-rpc" }
+    module("vanity") { artifact = "sava-vanity" }
+  }
+  versions("gradle/versions")
+}
 
 dependencyResolutionManagement {
   versionCatalogs {

--- a/vanity/build.gradle.kts
+++ b/vanity/build.gradle.kts
@@ -2,11 +2,6 @@ plugins {
   id("software.sava.gradle.feature.jlink")
 }
 
-dependencies {
-  implementation(libs.sava.json.iterator)
-  implementation(project(":sava-core"))
-}
-
 jlinkApplication {
   applicationName = "vanity"
   mainClass = "software.sava.vanity.Entrypoint"


### PR DESCRIPTION
Configures the build to take dependencies from `module-info` files and to do "whitebox" testing on the module path.

Follows a similar setup as:
- https://github.com/jjohannes/gradle-project-setup-howto/tree/java_module_system
- https://github.com/jjohannes/java-module-system
- https://github.com/hiero-ledger/hiero-consensus-node